### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pmd.yml
+++ b/.github/workflows/pmd.yml
@@ -1,4 +1,7 @@
 name: 🔍 PMD Apex Scan
+permissions:
+  contents: read
+  security-events: write
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/CLOUDQ-esron/Interns-HUB/security/code-scanning/18](https://github.com/CLOUDQ-esron/Interns-HUB/security/code-scanning/18)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Based on the provided workflow, the following permissions are needed:
- `contents: read` to allow the workflow to read repository contents.
- `security-events: write` to upload the SARIF report to GitHub Code Scanning.

The `permissions` block should be added at the top level of the workflow, just below the `name` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
